### PR TITLE
devices: add add Qualcomm Atheros IPQ6018 WiSoC compatible

### DIFF
--- a/devices.txt
+++ b/devices.txt
@@ -246,6 +246,7 @@
 "qca,qca9550-wmac"      0      0  "Qualcomm Atheros"  "QCA9550"
 "qca,qca9560-wmac"      0      0  "Qualcomm Atheros"  "QCA9560"
 "qcom,ipq4019-wifi"     0      0  "Qualcomm Atheros" "IPQ4019"
+"qcom,ipq6018-wifi"     0      0  "Qualcomm Atheros" "IPQ6018"
 "qcom,ipq8074-wifi"     0      0  "Qualcomm Atheros" "IPQ8074"
 "mediatek,mt7622-wmac"  0      0  "MediaTek" "MT7622"
 "mediatek,mt7628-wmac"  0      0  "MediaTek" "MT7628"


### PR DESCRIPTION
This adds detection for the Qualcomm Atheros IPQ6018 WiSoC.