### PR TITLE
iwinfo: fix EHT mode reporting for STA interfaces

### DIFF
--- a/iwinfo_nl80211.c
+++ b/iwinfo_nl80211.c
@@ -3383,41 +3383,53 @@ static int nl80211_get_htmode(const char *ifname, int *buf)
 
 	if (nl80211_hostapd_query(res ? res : ifname, "ieee80211ax", b, sizeof(b)))
 		he = b[0] == '1';
-	else if (nl80211_wpactl_query(res ? res : ifname, "wifi_generation", b, sizeof(b)))
+	else if (nl80211_wpactl_query(res ? res : ifname, "wifi_generation", b, sizeof(b))) {
 		he = b[0] == '6';
+		eht = b[0] == '7';
+	}
 
 	switch (chn.width) {
 	case NL80211_CHAN_WIDTH_20:
-		if (he)
-			*buf = (eht == true) ? IWINFO_HTMODE_EHT20 : IWINFO_HTMODE_HE20;
+		if (eht)
+			*buf = IWINFO_HTMODE_EHT20;
+		else if (he)
+			*buf = IWINFO_HTMODE_HE20;
 		else if (chn.mode == -1)
 			*buf = IWINFO_HTMODE_VHT20;
 		else
 			*buf = IWINFO_HTMODE_HT20;
 		break;
 	case NL80211_CHAN_WIDTH_40:
-		if (he)
-			*buf = (eht == true) ? IWINFO_HTMODE_EHT40 : IWINFO_HTMODE_HE40;
+		if (eht)
+			*buf = IWINFO_HTMODE_EHT40;
+		else if (he)
+			*buf = IWINFO_HTMODE_HE40;
 		else if (chn.mode == -1)
 			*buf = IWINFO_HTMODE_VHT40;
 		else
 			*buf = IWINFO_HTMODE_HT40;
 		break;
 	case NL80211_CHAN_WIDTH_80:
-		if (he)
-			*buf = (eht == true) ? IWINFO_HTMODE_EHT80 : IWINFO_HTMODE_HE80;
+		if (eht)
+			*buf = IWINFO_HTMODE_EHT80;
+		else if (he)
+			*buf = IWINFO_HTMODE_HE80;
 		else
 			*buf = IWINFO_HTMODE_VHT80;
 		break;
 	case NL80211_CHAN_WIDTH_80P80:
-		if (he)
-			*buf = (eht == true) ? IWINFO_HTMODE_EHT80_80 : IWINFO_HTMODE_HE80_80;
+		if (eht)
+			*buf = IWINFO_HTMODE_EHT80_80;
+		else if (he)
+			*buf = IWINFO_HTMODE_HE80_80;
 		else
 			*buf = IWINFO_HTMODE_VHT80_80;
 		break;
 	case NL80211_CHAN_WIDTH_160:
-		if (he)
-			*buf = (eht == true) ? IWINFO_HTMODE_EHT160 : IWINFO_HTMODE_HE160;
+		if (eht)
+			*buf = IWINFO_HTMODE_EHT160;
+		else if (he)
+			*buf = IWINFO_HTMODE_HE160;
 		else
 			*buf = IWINFO_HTMODE_VHT160;
 		break;


### PR DESCRIPTION
If reported wifi_generation is 7, correctly report EHT mode.

I missed this in the first pass of EHT additions.. STA mode interfaces operating in EHT mode report VHT without this patch.