### PR TITLE
lua: expose rx_bytes and tx_bytes

### DIFF
--- a/iwinfo_lua.c
+++ b/iwinfo_lua.c
@@ -363,6 +363,12 @@ static int iwinfo_L_assoclist(lua_State *L, int (*func)(const char *, char *, in
 			lua_pushnumber(L, e->tx_packets);
 			lua_setfield(L, -2, "tx_packets");
 
+			lua_pushnumber(L, e->rx_bytes);
+			lua_setfield(L, -2, "rx_bytes");
+
+			lua_pushnumber(L, e->tx_bytes);
+			lua_setfield(L, -2, "tx_bytes");
+
 			set_rateinfo(L, &e->rx_rate, true);
 			set_rateinfo(L, &e->tx_rate, false);
 


### PR DESCRIPTION
The prometheus-node-exporter package looks for these fields, but they are not currently exposed.

https://github.com/openwrt/packages/blob/de9f4eb3245892469de9563eb077a9250cbb3ddd/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/wifi_stations.lua#L56C1-L61C14