### PR TITLE
iwinfo: generic improvement of assoclist handling

### DIFF
--- a/include/iwinfo.h
+++ b/include/iwinfo.h
@@ -409,6 +409,10 @@ struct iwinfo_ops {
 	int (*hardware_name)(const char *, char *);
 	int (*encryption)(const char *, char *);
 	int (*phyname)(const char *, char *);
+	/*
+	 * Third element is always set to the size of the buffer.
+	 * assoclist should stop parsing elements if this is reached.
+	 */
 	int (*assoclist)(const char *, char *, int *);
 	int (*txpwrlist)(const char *, char *, int *);
 	int (*scanlist)(const char *, char *, int *);

--- a/include/iwinfo.h
+++ b/include/iwinfo.h
@@ -410,6 +410,9 @@ struct iwinfo_ops {
 	int (*encryption)(const char *, char *);
 	int (*phyname)(const char *, char *);
 	/*
+	 * assoclist might receive a NULL buf as second element.
+	 * In such case assoclist should only return the length
+	 * of the expected buffer.
 	 * Third element is always set to the size of the buffer.
 	 * assoclist should stop parsing elements if this is reached.
 	 */

--- a/iwinfo_cli.c
+++ b/iwinfo_cli.c
@@ -784,10 +784,11 @@ static void print_freqlist(const struct iwinfo_ops *iw, const char *ifname)
 
 static void print_assoclist(const struct iwinfo_ops *iw, const char *ifname)
 {
-	int i, len;
+	int i, len = IWINFO_BUFSIZE;
 	char buf[IWINFO_BUFSIZE];
 	struct iwinfo_assoclist_entry *e;
 
+	/* Pass to assoclist the size of buf allocated with len */
 	if (iw->assoclist(ifname, buf, &len))
 	{
 		printf("No information available\n");

--- a/iwinfo_madwifi.c
+++ b/iwinfo_madwifi.c
@@ -773,7 +773,7 @@ static int madwifi_get_assoclist(const char *ifname, char *buf, int *len)
 			si = (struct ieee80211req_sta_info *) cp;
 
 			/* stop parsing more elements as we reached max buf */
-			if (bl + sizeof(entry) > IWINFO_BUFSIZE)
+			if (bl + sizeof(entry) > *len)
 				break;
 
 			memset(&entry, 0, sizeof(entry));

--- a/iwinfo_madwifi.c
+++ b/iwinfo_madwifi.c
@@ -772,6 +772,10 @@ static int madwifi_get_assoclist(const char *ifname, char *buf, int *len)
 		do {
 			si = (struct ieee80211req_sta_info *) cp;
 
+			/* If buf is NULL, we only count the station */
+			if (!buf)
+				goto next;
+
 			/* stop parsing more elements as we reached max buf */
 			if (bl + sizeof(entry) > *len)
 				break;
@@ -801,6 +805,7 @@ static int madwifi_get_assoclist(const char *ifname, char *buf, int *len)
 
 			memcpy(&buf[bl], &entry, sizeof(struct iwinfo_assoclist_entry));
 
+next:
 			bl += sizeof(struct iwinfo_assoclist_entry);
 			cp += si->isi_len;
 			tl -= si->isi_len;

--- a/iwinfo_madwifi.c
+++ b/iwinfo_madwifi.c
@@ -772,6 +772,10 @@ static int madwifi_get_assoclist(const char *ifname, char *buf, int *len)
 		do {
 			si = (struct ieee80211req_sta_info *) cp;
 
+			/* stop parsing more elements as we reached max buf */
+			if (bl + sizeof(entry) > IWINFO_BUFSIZE)
+				break;
+
 			memset(&entry, 0, sizeof(entry));
 
 			entry.signal = (si->isi_rssi - 95);

--- a/iwinfo_nl80211.c
+++ b/iwinfo_nl80211.c
@@ -2254,6 +2254,10 @@ static int nl80211_get_assoclist_cb(struct nl_msg *msg, void *arg)
 		[NL80211_RATE_INFO_SHORT_GI]     = { .type = NLA_FLAG   },
 	};
 
+	/* stop parsing more elements as we reached max buf */
+	if (arr->count >= arr->max)
+		return NL_STOP;
+
 	/* advance to end of array */
 	e += arr->count;
 	memset(e, 0, sizeof(*e));
@@ -2396,6 +2400,9 @@ static int nl80211_get_assoclist(const char *ifname, char *buf, int *len)
 	struct dirent *de;
 	struct nl80211_array_buf arr = { .buf = buf, .count = 0 };
 	struct iwinfo_assoclist_entry *e;
+
+	/* Limit element to the preallocated space */
+	arr.max = IWINFO_BUFSIZE / sizeof(*e);
 
 	if ((d = opendir("/sys/class/net")) != NULL)
 	{

--- a/iwinfo_nl80211.c
+++ b/iwinfo_nl80211.c
@@ -2401,8 +2401,12 @@ static int nl80211_get_assoclist(const char *ifname, char *buf, int *len)
 	struct nl80211_array_buf arr = { .buf = buf, .count = 0 };
 	struct iwinfo_assoclist_entry *e;
 
+	/* If len is not set, use IWINFO_BUFSIZE by default */
+	if (!*len)
+		*len = IWINFO_BUFSIZE;
+
 	/* Limit element to the preallocated space */
-	arr.max = IWINFO_BUFSIZE / sizeof(*e);
+	arr.max = *len / sizeof(*e);
 
 	if ((d = opendir("/sys/class/net")) != NULL)
 	{

--- a/iwinfo_nl80211.c
+++ b/iwinfo_nl80211.c
@@ -2254,6 +2254,10 @@ static int nl80211_get_assoclist_cb(struct nl_msg *msg, void *arg)
 		[NL80211_RATE_INFO_SHORT_GI]     = { .type = NLA_FLAG   },
 	};
 
+	/* With NULL buf, we just count the stations */
+	if (!arr->buf)
+		goto exit;
+
 	/* stop parsing more elements as we reached max buf */
 	if (arr->count >= arr->max)
 		return NL_STOP;
@@ -2373,6 +2377,8 @@ static int nl80211_get_assoclist_cb(struct nl_msg *msg, void *arg)
 	}
 
 	e->noise = 0; /* filled in by caller */
+
+exit:
 	arr->count++;
 
 	return NL_SKIP;
@@ -2423,7 +2429,8 @@ static int nl80211_get_assoclist(const char *ifname, char *buf, int *len)
 
 		closedir(d);
 
-		if (!nl80211_get_noise(ifname, &noise))
+		/* Skip setting noise if we are just counting station */
+		if (arr.buf && !nl80211_get_noise(ifname, &noise))
 			for (i = 0, e = arr.buf; i < arr.count; i++, e++)
 				e->noise = noise;
 

--- a/iwinfo_nl80211.h
+++ b/iwinfo_nl80211.h
@@ -67,6 +67,7 @@ struct nl80211_rssi_rate {
 struct nl80211_array_buf {
 	void *buf;
 	int count;
+	int max;
 };
 
 #endif


### PR DESCRIPTION
This small PR makes generic improvement of assoclist handling.

Idea is to prevent any API change. User still needs to update their function to account for NULL buffer and len but updates likes that will only improve a fragile code.

This improves the assoc list and maybe also reduce the memory footprint. Allocating a big enough BUFFER is problematic for assoclist as it can grow a lot as it will contain info for every associated station.

To handle this, implement common practice way to get the number of element to alloc and dynamically alloc the space.
To apply this logic assoc list function needs to be called twice but this should not cause additional overhead.