### PR TITLE
nl80211: fix corrupt scan results from wpa_supplicant

### DIFF
--- a/iwinfo_nl80211.c
+++ b/iwinfo_nl80211.c
@@ -3026,6 +3026,8 @@ static int nl80211_get_scanlist_wpactl(const char *ifname, char *buf, int *len)
 			if (!bssid || !freq || !signal || !flags)
 				continue;
 
+			memset(e, 0, sizeof(*e));
+
 			/* BSSID */
 			e->mac[0] = strtol(&bssid[0],  NULL, 16);
 			e->mac[1] = strtol(&bssid[3],  NULL, 16);


### PR DESCRIPTION
Without clearing the scanlist entries, it was possible to have bad data remaining from previous calls in the ht_operation/vht_operation fields (not set here).  This could cause segfaults in rpcd's iwinfo module, as it was possible that (a) the primary_chan would not be 0 and therefore (b) you would use bad data for chan_width etc.  as an index into short-ish array:

	if (e->ht_chan_info.primary_chan) {
		t = blobmsg_open_table(&buf, "ht_operation");
		blobmsg_add_u32(&buf, "primary_channel", e->ht_chan_info.primary_chan);
		blobmsg_add_string(&buf, "secondary_channel_offset", ht_secondary_offset[e->ht_chan_info.secondary_chan_off]);
		blobmsg_add_u32(&buf, "channel_width", ht_chan_width[e->ht_chan_info.chan_width]);
		blobmsg_close_table(&buf, t);
	}