### PR TITLE
nl80211: fix freqlist reporting garbage flags

### DIFF
--- a/iwinfo_nl80211.c
+++ b/iwinfo_nl80211.c
@@ -3220,6 +3220,7 @@ static int nl80211_get_freqlist_cb(struct nl_msg *msg, void *arg)
 					    freqs[NL80211_FREQUENCY_ATTR_DISABLED])
 						continue;
 
+                    memset(e, 0, sizeof(*e));
 					e->band = nl80211_get_band(band->nla_type);
 					e->mhz = nla_get_u32(freqs[NL80211_FREQUENCY_ATTR_FREQ]);
 					e->channel = nl80211_freq2channel(e->mhz);


### PR DESCRIPTION
Without zeroing the buffer used in freqlist, the flags are OR'd against the values previously populated in the buffer causing it to report garbage values. This is particularly noticeable in rpcd's iwinfo module, where the buffer used will fill up on activity.