### PR TITLE
nl80211: bounds-check array_buf callbacks and grow assoclist buffer

### DIFF
--- a/include/iwinfo.h
+++ b/include/iwinfo.h
@@ -21,6 +21,7 @@
 
 
 #define IWINFO_BUFSIZE	24 * 1024
+#define IWINFO_ASSOCLIST_BUFSIZE	96 * 1024
 #define IWINFO_ESSID_MAX_SIZE	32
 
 enum iwinfo_80211 {

--- a/iwinfo_cli.c
+++ b/iwinfo_cli.c
@@ -820,7 +820,7 @@ static void print_freqlist(const struct iwinfo_ops *iw, const char *ifname)
 static void print_assoclist(const struct iwinfo_ops *iw, const char *ifname)
 {
 	int i, len;
-	char buf[IWINFO_BUFSIZE];
+	char buf[IWINFO_ASSOCLIST_BUFSIZE];
 	struct iwinfo_assoclist_entry *e;
 
 	if (iw->assoclist(ifname, buf, &len))

--- a/iwinfo_lua.c
+++ b/iwinfo_lua.c
@@ -328,7 +328,7 @@ static void set_rateinfo(lua_State *L, struct iwinfo_rate_entry *r, bool rx)
 static int iwinfo_L_assoclist(lua_State *L, int (*func)(const char *, char *, int *))
 {
 	int i, len;
-	char rv[IWINFO_BUFSIZE];
+	char rv[IWINFO_ASSOCLIST_BUFSIZE];
 	char macstr[18];
 	const char *ifname = luaL_checkstring(L, 1);
 	struct iwinfo_assoclist_entry *e;

--- a/iwinfo_nl80211.c
+++ b/iwinfo_nl80211.c
@@ -2232,6 +2232,9 @@ static int nl80211_get_survey_cb(struct nl_msg *msg, void *arg)
 	if (rc)
 		return NL_SKIP;
 
+	if (arr->count >= arr->max_count)
+		return NL_SKIP;
+
 	/* advance to end of array */
 	e += arr->count;
 	memset(e, 0, sizeof(*e));
@@ -2357,6 +2360,9 @@ static int nl80211_get_assoclist_cb(struct nl_msg *msg, void *arg)
 		[NL80211_RATE_INFO_SHORT_GI]     = { .type = NLA_FLAG   },
 	};
 
+	if (arr->count >= arr->max_count)
+		return NL_SKIP;
+
 	/* advance to end of array */
 	e += arr->count;
 	memset(e, 0, sizeof(*e));
@@ -2479,7 +2485,11 @@ static int nl80211_get_assoclist_cb(struct nl_msg *msg, void *arg)
 
 static int nl80211_get_survey(const char *ifname, char *buf, int *len)
 {
-	struct nl80211_array_buf arr = { .buf = buf, .count = 0 };
+	struct nl80211_array_buf arr = {
+		.buf = buf,
+		.count = 0,
+		.max_count = IWINFO_BUFSIZE / sizeof(struct iwinfo_survey_entry),
+	};
 	int rc;
 
 	rc = nl80211_request(ifname, NL80211_CMD_GET_SURVEY,
@@ -2497,7 +2507,11 @@ static int nl80211_get_assoclist(const char *ifname, char *buf, int *len)
 	DIR *d;
 	int i, noise = 0;
 	struct dirent *de;
-	struct nl80211_array_buf arr = { .buf = buf, .count = 0 };
+	struct nl80211_array_buf arr = {
+		.buf = buf,
+		.count = 0,
+		.max_count = IWINFO_BUFSIZE / sizeof(struct iwinfo_assoclist_entry),
+	};
 	struct iwinfo_assoclist_entry *e;
 
 	if ((d = opendir("/sys/class/net")) != NULL)
@@ -3220,6 +3234,9 @@ static int nl80211_get_freqlist_cb(struct nl_msg *msg, void *arg)
 					    freqs[NL80211_FREQUENCY_ATTR_DISABLED])
 						continue;
 
+					if (arr->count >= arr->max_count)
+						return NL_SKIP;
+
 					e->band = nl80211_get_band(band->nla_type);
 					e->mhz = nla_get_u32(freqs[NL80211_FREQUENCY_ATTR_FREQ]);
 					e->channel = nl80211_freq2channel(e->mhz);
@@ -3260,7 +3277,11 @@ static int nl80211_get_freqlist_cb(struct nl_msg *msg, void *arg)
 static int nl80211_get_freqlist(const char *ifname, char *buf, int *len)
 {
 	struct nl80211_msg_conveyor *cv;
-	struct nl80211_array_buf arr = { .buf = buf, .count = 0 };
+	struct nl80211_array_buf arr = {
+		.buf = buf,
+		.count = 0,
+		.max_count = IWINFO_BUFSIZE / sizeof(struct iwinfo_freqlist_entry),
+	};
 	uint32_t features = nl80211_get_protocol_features(ifname);
 	int flags;
 

--- a/iwinfo_nl80211.c
+++ b/iwinfo_nl80211.c
@@ -2510,7 +2510,7 @@ static int nl80211_get_assoclist(const char *ifname, char *buf, int *len)
 	struct nl80211_array_buf arr = {
 		.buf = buf,
 		.count = 0,
-		.max_count = IWINFO_BUFSIZE / sizeof(struct iwinfo_assoclist_entry),
+		.max_count = IWINFO_ASSOCLIST_BUFSIZE / sizeof(struct iwinfo_assoclist_entry),
 	};
 	struct iwinfo_assoclist_entry *e;
 

--- a/iwinfo_nl80211.h
+++ b/iwinfo_nl80211.h
@@ -67,6 +67,7 @@ struct nl80211_rssi_rate {
 struct nl80211_array_buf {
 	void *buf;
 	int count;
+	int max_count;
 };
 
 #endif


### PR DESCRIPTION
The nl80211 get_survey, get_assoclist and get_freqlist callbacks
append to a caller-provided IWINFO_BUFSIZE (24 KiB) stack buffer
without ever checking that the buffer still has room. For assoclist in
particular, `struct iwinfo_assoclist_entry` is ~176 bytes, so the
buffer only holds ~139 stations before overflowing the caller's stack
and crashing libiwinfo consumers (LuCI, ubus, the `iwinfo` CLI). This
has been observed in deployments with hundreds of associated stations.

This series fixes that in two steps:

1. **`nl80211: bounds-check array_buf callbacks against buffer capacity`**
   Add a `max_count` to `struct nl80211_array_buf`, set it from
   `IWINFO_BUFSIZE / sizeof(entry)` in the three callers
   (`nl80211_get_survey`, `nl80211_get_assoclist`, `nl80211_get_freqlist`)
   and skip further appends once the limit is reached. On its own this
   turns the crash into a (still unfortunate) truncated result.

2. **`increase assoclist buffer to support up to ~558 stations`**
   Introduce a dedicated `IWINFO_ASSOCLIST_BUFSIZE` (96 KiB) and use it
   only for the two assoclist call sites (`print_assoclist` and the lua
   binding) and the matching `max_count` in `nl80211_get_assoclist`.
   The other ops keep the 24 KiB `IWINFO_BUFSIZE` so we don't inflate
   every caller's stack frame for ops whose entry counts are inherently
   small (txpwrlist, countrylist, freqlist, ...).

After this, ~558 associated stations fit cleanly; anything beyond that
is truncated instead of crashing. Tested with the OpenWrt build on
powerpc_e500mc (Westermo deployments with up to 512 stations).