### PR TITLE
nl80211: clear nl80211 freqlist entry

### DIFF
--- a/iwinfo_nl80211.c
+++ b/iwinfo_nl80211.c
@@ -3220,6 +3220,8 @@ static int nl80211_get_freqlist_cb(struct nl_msg *msg, void *arg)
 					    freqs[NL80211_FREQUENCY_ATTR_DISABLED])
 						continue;
 
+					memset(e, 0, sizeof(*e));
+
 					e->band = nl80211_get_band(band->nla_type);
 					e->mhz = nla_get_u32(freqs[NL80211_FREQUENCY_ATTR_FREQ]);
 					e->channel = nl80211_freq2channel(e->mhz);


### PR DESCRIPTION
Zero the freqlist entry before filling it in nl80211_get_freqlist_cb().

Without this, long-lived processes such as rpcd can reuse dirty stack contents and keep random bits in the exported data. This shows up in ubus iwinfo freqlist replies as bogus flags such as no_10mhz and no_20mhz, even though they are not actually set.

Clear the whole entry first so only flags reported by nl80211 are returned.

related PR https://github.com/openwrt/openwrt/pull/23461
