### PR TITLE
Add device id for Qualcomm QCN5502

### DIFF
--- a/devices.txt
+++ b/devices.txt
@@ -259,6 +259,7 @@
 "qca,qca9530-wmac"      0      0  "Qualcomm Atheros"  "QCA9530"
 "qca,qca9550-wmac"      0      0  "Qualcomm Atheros"  "QCA9550"
 "qca,qca9560-wmac"      0      0  "Qualcomm Atheros"  "QCA9560"
+"qca,qcn5502-wifi"      0      0  "Qualcomm" "QCN5502"
 "qcom,ipq4019-wifi"     0      0  "Qualcomm Atheros" "IPQ4019"
 "qcom,ipq5018-wifi"     0      0  "Qualcomm Atheros" "IPQ5018"
 "qcom,ipq6018-wifi"     0      0  "Qualcomm Atheros" "IPQ6018"


### PR DESCRIPTION
Depends on https://github.com/openwrt/openwrt/pull/24342 .

Found on:

 - ASUS RT-AC59U / RT-AC59U v2 (RT-AC1200GE, RT-AC1300G PLUS, RT-AC1500UHP, RT-AC57U v2/v3, RT-AC58U v2/v3, RT-ACRH12 etc)

 - ASUS ZenWiFi AC Mini(CD6)

 - Netgear EX7300 v2 (EX6250 / EX6400 v2 / EX6410 / EX6420 /EX7320)

 - TP-Link Archer A9 v6